### PR TITLE
fix(routes): set '/' to Home and keep '/audit' for audit report

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,7 +4,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { BrowserRouter, Routes, Route } from "react-router-dom";
 import { HelmetProvider } from "react-helmet-async";
 import { useEffect } from "react";
-import Index from "./pages/Index";
+import HomePage from "./pages/HomePage";
 import AuditReport from "./pages/AuditReport";
 import NotFound from "./pages/NotFound";
 import { ScrollToTop } from "./components/ui/ScrollToTop";
@@ -50,7 +50,7 @@ const App = () => {
           <BrowserRouter>
             <ScrollToTop />
             <Routes>
-              <Route path="/" element={<Index />} />
+              <Route path="/" element={<HomePage />} />
               <Route path="/audit" element={<AuditReport />} />
               {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
               <Route path="*" element={<NotFound />} />


### PR DESCRIPTION
## Summary
- import the main HomePage component into the app router
- point the root route to HomePage while keeping /audit mapped to the audit report
- ensure only the shared Toaster component is rendered

## Testing
- pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68e1690cbb508322a39207c0cec3c811