### PR TITLE
feat: wire public pages to cached data sources

### DIFF
--- a/src/components/ArticleCard.tsx
+++ b/src/components/ArticleCard.tsx
@@ -1,5 +1,7 @@
 import { Link } from 'react-router-dom';
 
+import { OptimizedImage } from '@/components/ui/OptimizedImage';
+
 interface ArticleCardProps {
   id: string;
   title: string;
@@ -9,17 +11,15 @@ interface ArticleCardProps {
 }
 
 const ArticleCard = ({ id, title, description, imageUrl, onClick }: ArticleCardProps) => {
+  const safeImageUrl = imageUrl || '/placeholder.svg';
+
   return (
     <Link to={`/articles/${id}`} onClick={onClick}>
       <article className="group flex flex-col gap-3">
         <div className="overflow-hidden rounded-lg">
-          <img
-            src={`${imageUrl}?w=1200&q=80`}
-            srcSet={`${imageUrl}?w=600&q=70 600w, ${imageUrl}?w=900&q=70 900w, ${imageUrl}?w=1200&q=80 1200w`}
-            sizes="(max-width: 768px) 100vw, 50vw"
+          <OptimizedImage
+            src={safeImageUrl}
             alt={title}
-            loading="lazy"
-            decoding="async"
             className="aspect-video w-full rounded-lg object-cover transition-transform duration-300 group-hover:scale-110"
           />
         </div>

--- a/src/components/ArticleHero.tsx
+++ b/src/components/ArticleHero.tsx
@@ -1,21 +1,23 @@
 import React from 'react';
 
+import { OptimizedImage } from '@/components/ui/OptimizedImage';
+
 interface ArticleHeroProps {
   imageUrl: string;
   alt: string;
 }
 
 const ArticleHero: React.FC<ArticleHeroProps> = ({ imageUrl, alt }) => {
+  const safeImageUrl = imageUrl || '/placeholder.svg';
+
   return (
-    <div className="mb-8 rounded-xl overflow-hidden">
-      <div className="w-full aspect-[16/9] relative">
-        <img
-          src={imageUrl}
+    <div className="mb-8 overflow-hidden rounded-xl">
+      <div className="relative aspect-[16/9] w-full">
+        <OptimizedImage
+          src={safeImageUrl}
           alt={alt}
-          loading="eager"
-          decoding="async"
-          fetchPriority="high"
-          className="w-full h-full object-cover"
+          className="h-full w-full object-cover"
+          priority
         />
       </div>
     </div>

--- a/src/components/ArticleList.tsx
+++ b/src/components/ArticleList.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
-import type { Article } from '../pages/CategoryPage';
+
+import { OptimizedImage } from '@/components/ui/OptimizedImage';
+import type { Article } from '@/types/article';
 
 interface ArticleListProps {
   articles: Article[];
@@ -17,7 +19,11 @@ const ArticleList: React.FC<ArticleListProps> = ({ articles }) => {
     );
   }
 
-  const formatDate = (dateString: string): string => {
+  const formatDate = (dateString: string | null | undefined): string => {
+    if (!dateString) {
+      return '';
+    }
+
     const date = new Date(dateString);
     return date.toLocaleDateString('fr-FR', {
       year: 'numeric',
@@ -33,7 +39,7 @@ const ArticleList: React.FC<ArticleListProps> = ({ articles }) => {
           <article className="group grid md:grid-cols-3 gap-6 items-center">
             <div className="md:col-span-2">
               <div className="flex flex-col gap-3">
-                <Link to={`/article/${article.id}`}>
+                <Link to={`/articles/${article.id}`}>
                   <h3 className="text-xl font-bold text-neutral-900 dark:text-white group-hover:text-primary transition-colors">
                     {article.title}
                   </h3>
@@ -46,21 +52,12 @@ const ArticleList: React.FC<ArticleListProps> = ({ articles }) => {
                 </p>
               </div>
             </div>
-            <Link to={`/article/${article.id}`} className="w-full overflow-hidden rounded-lg">
-              <div
-                className="w-full bg-center bg-no-repeat aspect-video bg-cover transition-transform duration-300 group-hover:scale-105"
-                style={{ backgroundImage: `url("${article.image_url}")` }}
-                role="img"
-                aria-label={article.title}
-              >
-                <img
-                  src={article.image_url}
-                  alt={article.title}
-                  loading="lazy"
-                  decoding="async"
-                  className="w-full h-full object-cover opacity-0"
-                />
-              </div>
+            <Link to={`/articles/${article.id}`} className="w-full overflow-hidden rounded-lg">
+              <OptimizedImage
+                src={article.image_url || '/placeholder.svg'}
+                alt={article.title ?? 'Article'}
+                className="aspect-video w-full rounded-lg object-cover transition-transform duration-300 group-hover:scale-105"
+              />
             </Link>
           </article>
           {index < articles.length - 1 && (

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -1,3 +1,5 @@
+import { OptimizedImage } from '@/components/ui/OptimizedImage';
+
 interface HeroProps {
   title: string;
   description: string;
@@ -6,27 +8,26 @@ interface HeroProps {
   onButtonClick?: () => void;
 }
 
-export const Hero = ({ 
-  title, 
-  description, 
-  imageUrl, 
+export const Hero = ({
+  title,
+  description,
+  imageUrl,
   buttonText = "Read More",
-  onButtonClick 
+  onButtonClick
 }: HeroProps) => {
+  const safeImageUrl = imageUrl || '/placeholder.svg';
+
   return (
     <div className="@container">
       <div className="group relative flex min-h-[520px] items-end justify-start overflow-hidden rounded-xl p-10">
-        <img
-          src={`${imageUrl}?w=1200&q=80`}
-          srcSet={`${imageUrl}?w=600&q=70 600w, ${imageUrl}?w=900&q=70 900w, ${imageUrl}?w=1200&q=80 1200w`}
-          sizes="100vw"
+        <OptimizedImage
+          src={safeImageUrl}
           alt={title}
-          fetchPriority="high"
-          decoding="async"
           className="absolute inset-0 -z-10 h-full w-full object-cover"
+          priority
         />
         <div className="absolute inset-0 -z-10 bg-gradient-to-b from-black/10 to-black/60" />
-        
+
         <div className="flex max-w-3xl flex-col gap-4 text-left">
           <div className="flex flex-col gap-2">
             <h1 className="text-5xl font-extrabold text-white">{title}</h1>
@@ -35,7 +36,7 @@ export const Hero = ({
             </h2>
           </div>
           {buttonText && (
-            <button 
+            <button
               onClick={onButtonClick}
               className="mt-2 h-12 w-fit rounded-full bg-primary px-6 text-base font-bold text-white transition-transform group-hover:scale-105"
             >

--- a/src/components/SearchResultCard.tsx
+++ b/src/components/SearchResultCard.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
 
+import { OptimizedImage } from '@/components/ui/OptimizedImage';
+
 export interface SearchResult {
   id: string;
   title: string;
@@ -15,14 +17,14 @@ interface SearchResultCardProps {
 }
 
 export const SearchResultCard: React.FC<SearchResultCardProps> = ({ result }) => {
+  const imageUrl = result.imageUrl || '/placeholder.svg';
+
   return (
-    <article className="flex flex-col sm:flex-row gap-6 group">
+    <article className="flex flex-col gap-6 sm:flex-row group">
       <div className="sm:w-1/3">
-        <img
-          src={result.imageUrl}
+        <OptimizedImage
+          src={imageUrl}
           alt={result.title}
-          loading="lazy"
-          decoding="async"
           className="aspect-video w-full rounded-lg object-cover"
         />
       </div>

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,0 +1,194 @@
+import { supabase } from './supabaseClient';
+import type {
+  Article,
+  CachedArticleResponse,
+  CachedCategoryResponse,
+  CachedSearchResponse,
+} from '@/types/article';
+
+const supabaseUrl = import.meta.env.VITE_SUPABASE_URL;
+const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY;
+
+const functionHeaders: HeadersInit | undefined = supabaseAnonKey
+  ? {
+      apikey: supabaseAnonKey,
+      Authorization: `Bearer ${supabaseAnonKey}`,
+    }
+  : undefined;
+
+const buildFunctionUrl = (path: string) => {
+  if (!supabaseUrl) {
+    return null;
+  }
+
+  const trimmedBase = supabaseUrl.replace(/\/$/, '');
+  const trimmedPath = path.startsWith('/') ? path : `/${path}`;
+  return `${trimmedBase}/functions/v1${trimmedPath}`;
+};
+
+async function fetchFromEdgeFunction<T>(path: string, signal?: AbortSignal): Promise<T | null> {
+  const url = buildFunctionUrl(path);
+  if (!url) {
+    return null;
+  }
+
+  try {
+    const response = await fetch(url, {
+      headers: functionHeaders,
+      signal,
+    });
+
+    if (!response.ok) {
+      console.warn(`Edge function ${path} responded with status ${response.status}`);
+      return null;
+    }
+
+    return (await response.json()) as T;
+  } catch (error) {
+    if (error instanceof DOMException && error.name === 'AbortError') {
+      return null;
+    }
+
+    console.error(`Failed to call edge function ${path}:`, error);
+    return null;
+  }
+}
+
+const mapArticle = (article: Article): Article => ({
+  ...article,
+  summary: article.summary ?? '',
+  image_url: article.image_url ?? '',
+  category: article.category ?? '',
+  publish_at: article.publish_at ?? '',
+  country: article.country ?? '',
+  source: article.source ?? '',
+});
+
+export const fetchHomeArticles = async (signal?: AbortSignal): Promise<Article[]> => {
+  const homeApiUrl = import.meta.env.VITE_HOME_API_URL || '/api/home';
+
+  try {
+    const response = await fetch(homeApiUrl, { signal });
+
+    if (!response.ok) {
+      throw new Error(`Home API responded with status ${response.status}`);
+    }
+
+    const payload = (await response.json()) as Article[];
+    return payload.map(mapArticle);
+  } catch (error) {
+    if (error instanceof DOMException && error.name === 'AbortError') {
+      throw error;
+    }
+
+    console.warn('Falling back to Supabase for home articles:', error);
+
+    const { data, error: supabaseError } = await supabase
+      .from('articles')
+      .select('id, title, summary, image_url, category, publish_at, status')
+      .eq('status', 'approved')
+      .lte('publish_at', new Date().toISOString())
+      .order('publish_at', { ascending: false })
+      .limit(6);
+
+    if (supabaseError) {
+      throw supabaseError;
+    }
+
+    return (data ?? []).map(mapArticle);
+  }
+};
+
+export const fetchCategoryArticles = async (
+  category: string,
+  signal?: AbortSignal,
+): Promise<CachedCategoryResponse> => {
+  const cached = await fetchFromEdgeFunction<CachedCategoryResponse>(`/cache-category/${encodeURIComponent(category)}`, signal);
+  if (cached) {
+    return {
+      ...cached,
+      articles: cached.articles.map(mapArticle),
+    };
+  }
+
+  const { data, error, count } = await supabase
+    .from('articles')
+    .select('*', { count: 'exact' })
+    .eq('category', category)
+    .eq('status', 'approved')
+    .lte('publish_at', new Date().toISOString())
+    .order('publish_at', { ascending: false })
+    .limit(50);
+
+  if (error) {
+    throw error;
+  }
+
+  return {
+    articles: (data ?? []).map(mapArticle),
+    count: count ?? data?.length ?? 0,
+    category,
+  };
+};
+
+export const fetchSearchResults = async (
+  query: string,
+  signal?: AbortSignal,
+): Promise<CachedSearchResponse> => {
+  const cached = await fetchFromEdgeFunction<CachedSearchResponse>(`/cache-search?q=${encodeURIComponent(query)}`, signal);
+  if (cached) {
+    return {
+      ...cached,
+      articles: cached.articles.map(mapArticle),
+    };
+  }
+
+  const { data, error, count } = await supabase
+    .from('articles')
+    .select('*', { count: 'exact' })
+    .eq('status', 'approved')
+    .lte('publish_at', new Date().toISOString())
+    .or(`title.ilike.%${query}%,summary.ilike.%${query}%`)
+    .order('publish_at', { ascending: false })
+    .limit(50);
+
+  if (error) {
+    throw error;
+  }
+
+  return {
+    articles: (data ?? []).map(mapArticle),
+    count: count ?? data?.length ?? 0,
+    query,
+  };
+};
+
+export const fetchArticleDetail = async (
+  id: string,
+  signal?: AbortSignal,
+): Promise<CachedArticleResponse> => {
+  const cached = await fetchFromEdgeFunction<CachedArticleResponse>(`/cache-article/${encodeURIComponent(id)}`, signal);
+  if (cached) {
+    return {
+      article: cached.article ? mapArticle(cached.article) : null,
+      relatedArticles: cached.relatedArticles.map(mapArticle),
+    };
+  }
+
+  const { data, error } = await supabase
+    .from('articles')
+    .select('*')
+    .eq('id', id)
+    .eq('status', 'approved')
+    .lte('publish_at', new Date().toISOString())
+    .single();
+
+  if (error) {
+    throw error;
+  }
+
+  return {
+    article: data ? mapArticle(data) : null,
+    relatedArticles: [],
+  };
+};

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -1,116 +1,74 @@
-import { useState, useEffect } from 'react';
-import { Hero } from '../components/Hero';
-import ArticleCard from '../components/ArticleCard';
+import { useEffect, useState } from 'react';
 
-interface Article {
-  id: string;
-  title: string;
-  summary: string;
-  image_url: string;
-  category: string;
-  publish_at: string;
-}
-
-interface CachedData {
-  t: number;
-  data: Article[];
-}
-
-const CACHE_KEY = 'homeFeed_v1';
-const FETCH_TIMEOUT = 4000; // 4 seconds
+import ArticleCard from '@/components/ArticleCard';
+import { Hero } from '@/components/Hero';
+import { ArticleCardSkeleton } from '@/components/ui/ArticleCardSkeleton';
+import { HeroSkeleton } from '@/components/ui/HeroSkeleton';
+import { OptimizedImage } from '@/components/ui/OptimizedImage';
+import { useToast } from '@/hooks/use-toast';
+import { fetchHomeArticles } from '@/lib/api';
+import type { Article } from '@/types/article';
 
 const HomePage = () => {
+  const { toast } = useToast();
   const [articles, setArticles] = useState<Article[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
     const controller = new AbortController();
-    let timeoutId: ReturnType<typeof setTimeout>;
+    let isMounted = true;
 
     const loadHomeFeed = async () => {
-      // a) Try to read from localStorage first
+      setLoading(true);
+      setError(null);
+
       try {
-        const cached = localStorage.getItem(CACHE_KEY);
-        if (cached) {
-          const parsedCache: CachedData = JSON.parse(cached);
-          setArticles(parsedCache.data);
-          setLoading(false); // No spinner if we have cached data
+        const data = await fetchHomeArticles(controller.signal);
+        if (!isMounted) {
+          return;
         }
+
+        setArticles(data);
       } catch (err) {
-        console.error('Error reading cache:', err);
-      }
-
-      // b) Fetch fresh data from API with timeout
-      try {
-        const fetchPromise = fetch('/api/home', {
-          signal: controller.signal,
-        });
-
-        const timeoutPromise = new Promise<never>((_, reject) => {
-          timeoutId = setTimeout(() => {
-            reject(new Error('Request timeout'));
-          }, FETCH_TIMEOUT);
-        });
-
-        const response = await Promise.race([fetchPromise, timeoutPromise]);
-        
-        clearTimeout(timeoutId);
-
-        if (!response.ok) {
-          throw new Error(`HTTP error! status: ${response.status}`);
+        if (err instanceof DOMException && err.name === 'AbortError') {
+          return;
         }
 
-        const newData: Article[] = await response.json();
-        
-        // Update state with fresh data
-        setArticles(newData);
-        setLoading(false);
-        setError(null);
-
-        // Update localStorage cache
-        const cacheData: CachedData = {
-          t: Date.now(),
-          data: newData,
-        };
-        localStorage.setItem(CACHE_KEY, JSON.stringify(cacheData));
-      } catch (err) {
-        if (err instanceof Error) {
-          if (err.name === 'AbortError') {
-            console.log('Fetch aborted');
-          } else {
-            console.error('Error fetching home feed:', err);
-            // Only show error if we don't have cached data
-            if (articles.length === 0) {
-              setError('Impossible de charger les articles. Veuillez réessayer plus tard.');
-            }
-          }
+        console.error('Error fetching home feed:', err);
+        if (!isMounted) {
+          return;
         }
-        setLoading(false);
+
+        setError("Impossible de charger les articles pour le moment.");
+        toast({
+          variant: 'destructive',
+          title: 'Erreur de chargement',
+          description: 'Nous n\'avons pas pu récupérer les derniers articles. Veuillez réessayer plus tard.',
+        });
+      } finally {
+        if (isMounted) {
+          setLoading(false);
+        }
       }
     };
 
-    loadHomeFeed();
+    void loadHomeFeed();
 
-    // Cleanup function
     return () => {
+      isMounted = false;
       controller.abort();
-      if (timeoutId) {
-        clearTimeout(timeoutId);
-      }
     };
-  }, []);
+  }, [toast]);
 
-  // Mock data pour le hero (sera remplacé par le premier article s'il existe)
-  const heroData = articles[0] ? {
-    title: articles[0].title,
-    description: articles[0].summary,
-    imageUrl: articles[0].image_url
-  } : {
-    title: "Chargement...",
-    description: "Veuillez patienter...",
-    imageUrl: ""
-  };
+  const heroArticle = articles[0];
+  const heroData = heroArticle
+    ? {
+        title: heroArticle.title,
+        description: heroArticle.summary ?? '',
+        imageUrl: heroArticle.image_url ?? '',
+      }
+    : null;
 
   const trendingTopics = [
     "Presidential Elections",
@@ -120,67 +78,53 @@ const HomePage = () => {
     "Regional Integration"
   ];
 
+  const filterByCategory = (category: string) =>
+    articles.filter(article => (article.category ?? '').toLowerCase() === category);
+
   // Show loading skeleton only if no cached data and no network data yet
-  if (loading && articles.length === 0) {
-    return (
-      <main className="flex flex-1 items-center justify-center px-10 py-8">
-        <div className="text-center">
-          <div className="mb-4 inline-block h-12 w-12 animate-spin rounded-full border-4 border-solid border-primary border-r-transparent"></div>
-          <p className="text-lg text-black dark:text-white">Chargement des articles...</p>
-        </div>
-      </main>
-    );
-  }
-
-  if (error && articles.length === 0) {
-    return (
-      <main className="flex flex-1 items-center justify-center px-10 py-8">
-        <div className="text-center">
-          <p className="text-lg text-red-600 dark:text-red-400">{error}</p>
-          <button
-            onClick={() => window.location.reload()}
-            className="mt-4 rounded-lg bg-primary px-6 py-2 text-white hover:bg-primary/90"
-          >
-            Réessayer
-          </button>
-        </div>
-      </main>
-    );
-  }
-
   return (
     <main className="flex flex-1 justify-center px-10 py-8">
-          <div className="flex w-full max-w-7xl flex-col gap-12">
-            {/* Hero Section */}
-            {articles.length > 0 && (
-              <Hero
-                title={heroData.title}
-                description={heroData.description}
-                imageUrl={heroData.imageUrl}
-              />
-            )}
+      <div className="flex w-full max-w-7xl flex-col gap-12">
+        {loading && articles.length === 0 ? (
+          <HeroSkeleton />
+        ) : (
+          heroData && (
+            <Hero
+              title={heroData.title}
+              description={heroData.description}
+              imageUrl={heroData.imageUrl}
+            />
+          )
+        )}
 
-            {/* Articles Section */}
-            <section className="flex flex-col gap-6">
-              <h2 className="text-3xl font-bold text-black dark:text-white">Derniers Articles</h2>
-              {articles.length === 0 ? (
-                <p className="text-center text-black/60 dark:text-white/60">
-                  Aucun article disponible pour le moment.
-                </p>
-              ) : (
-                <div className="grid grid-cols-1 gap-8 sm:grid-cols-2 lg:grid-cols-3">
-                  {articles.slice(1).map((article) => (
-                    <ArticleCard
-                      key={article.id}
-                      id={article.id}
-                      title={article.title}
-                      description={article.summary}
-                      imageUrl={article.image_url}
-                    />
-                  ))}
-                </div>
-              )}
-            </section>
+        {error && (
+          <div className="rounded-md border border-red-200 bg-red-50 p-4 dark:border-red-900 dark:bg-red-950">
+            <p className="text-sm text-red-700 dark:text-red-200">{error}</p>
+          </div>
+        )}
+
+        <section className="flex flex-col gap-6">
+          <h2 className="text-3xl font-bold text-black dark:text-white">Derniers Articles</h2>
+          {loading && articles.length === 0 ? (
+            <ArticleCardSkeleton count={3} />
+          ) : articles.length === 0 ? (
+            <p className="text-center text-black/60 dark:text-white/60">
+              Aucun article disponible pour le moment. Revenez bientôt pour découvrir les dernières actualités.
+            </p>
+          ) : (
+            <div className="grid grid-cols-1 gap-8 sm:grid-cols-2 lg:grid-cols-3">
+              {articles.slice(1).map((article) => (
+                <ArticleCard
+                  key={article.id}
+                  id={article.id}
+                  title={article.title}
+                  description={article.summary ?? ''}
+                  imageUrl={article.image_url ?? ''}
+                />
+              ))}
+            </div>
+          )}
+        </section>
 
             {/* Politics + Trending Topics Grid */}
             <div className="grid grid-cols-1 gap-12 lg:grid-cols-3 lg:gap-8">
@@ -188,19 +132,18 @@ const HomePage = () => {
               <section className="flex flex-col gap-6 lg:col-span-2">
                 <h2 className="text-3xl font-bold text-black dark:text-white">Politique</h2>
                 <div className="grid grid-cols-1 gap-8 sm:grid-cols-2">
-                  {articles
-                    .filter(a => a.category === 'politique')
+                  {filterByCategory('politique')
                     .slice(0, 4)
                     .map((article) => (
                       <ArticleCard
                         key={article.id}
                         id={article.id}
                         title={article.title}
-                        description={article.summary}
-                        imageUrl={article.image_url}
+                        description={article.summary ?? ''}
+                        imageUrl={article.image_url ?? ''}
                       />
                     ))}
-                  {articles.filter(a => a.category === 'politique').length === 0 && (
+                  {filterByCategory('politique').length === 0 && (
                     <p className="col-span-2 text-center text-black/60 dark:text-white/60">
                       Aucun article politique disponible.
                     </p>
@@ -225,15 +168,17 @@ const HomePage = () => {
 
                 <h2 className="pt-6 text-3xl font-bold text-black dark:text-white">Opinion</h2>
                 <div className="flex flex-col gap-6">
-                  {articles
-                    .filter(a => a.category === 'opinion')
+                  {filterByCategory('opinion')
                     .slice(0, 3)
                     .map((article) => (
                       <article key={article.id} className="group flex items-start gap-4">
-                        <div
-                          className="h-24 w-32 shrink-0 overflow-hidden rounded-lg bg-cover bg-center bg-no-repeat"
-                          style={{ backgroundImage: `url("${article.image_url}")` }}
-                        />
+                        <div className="h-24 w-32 shrink-0 overflow-hidden rounded-lg">
+                          <OptimizedImage
+                            src={article.image_url ?? '/placeholder.svg'}
+                            alt={article.title ?? 'Article opinion'}
+                            className="h-full w-full object-cover"
+                          />
+                        </div>
                         <div>
                           <p className="text-sm font-semibold text-primary">Opinion</p>
                           <h3 className="font-bold text-black group-hover:text-primary dark:text-white dark:group-hover:text-primary">
@@ -243,7 +188,7 @@ const HomePage = () => {
                         </div>
                       </article>
                     ))}
-                  {articles.filter(a => a.category === 'opinion').length === 0 && (
+                  {filterByCategory('opinion').length === 0 && (
                     <p className="text-center text-sm text-black/60 dark:text-white/60">
                       Aucun article d'opinion disponible.
                     </p>
@@ -256,26 +201,25 @@ const HomePage = () => {
             <section className="flex flex-col gap-6">
               <h2 className="text-3xl font-bold text-black dark:text-white">Économie</h2>
               <div className="grid grid-cols-1 gap-8 sm:grid-cols-2 lg:grid-cols-4">
-                {articles
-                  .filter(a => a.category === 'economie')
+                {filterByCategory('economie')
                   .slice(0, 4)
                   .map((article) => (
                     <ArticleCard
                       key={article.id}
                       id={article.id}
                       title={article.title}
-                      description={article.summary}
-                      imageUrl={article.image_url}
+                      description={article.summary ?? ''}
+                      imageUrl={article.image_url ?? ''}
                     />
                   ))}
-                {articles.filter(a => a.category === 'economie').length === 0 && (
+                {filterByCategory('economie').length === 0 && (
                   <p className="col-span-4 text-center text-black/60 dark:text-white/60">
                     Aucun article économique disponible.
                   </p>
                 )}
               </div>
             </section>
-          </div>
+      </div>
     </main>
   );
 };

--- a/src/types/article.ts
+++ b/src/types/article.ts
@@ -1,0 +1,31 @@
+export interface Article {
+  id: string;
+  title: string;
+  summary: string | null;
+  image_url: string | null;
+  category: string | null;
+  publish_at: string | null;
+  status?: string | null;
+  body?: string | null;
+  author?: string | null;
+  country?: string | null;
+  source?: string | null;
+  created_at?: string | null;
+}
+
+export interface CachedCategoryResponse {
+  articles: Article[];
+  count: number;
+  category?: string;
+}
+
+export interface CachedSearchResponse {
+  articles: Article[];
+  count: number;
+  query: string;
+}
+
+export interface CachedArticleResponse {
+  article: Article | null;
+  relatedArticles: Article[];
+}


### PR DESCRIPTION
## Summary
- add a shared data client that prefers cached Supabase edge functions and falls back to direct queries
- refactor home, category, search, and article detail pages to use the new data layer with skeleton, empty, and toast error states
- reuse the OptimizedImage component across article surfaces and centralize article typings

## Testing
- pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68e1858cd6d08322b4d97a3088041774