### PR TITLE
Enhance article SEO metadata and sitemap generation

### DIFF
--- a/api/sitemap.xml.ts
+++ b/api/sitemap.xml.ts
@@ -1,0 +1,67 @@
+/// <reference types="node" />
+import { createClient } from '@supabase/supabase-js';
+import type { VercelRequest, VercelResponse } from '@vercel/node';
+
+const SITE_URL = process.env.SITE_URL ?? 'https://flashafrique.vercel.app';
+
+const buildArticleUrl = (id: string) => {
+  const trimmedBase = SITE_URL.replace(/\/$/, '');
+  return `${trimmedBase}/articles/${id}`;
+};
+
+const toIsoString = (value: string | null | undefined) => {
+  if (!value) {
+    return null;
+  }
+
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) {
+    return null;
+  }
+
+  return parsed.toISOString();
+};
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  if (req.method !== 'GET') {
+    res.setHeader('Allow', 'GET');
+    return res.status(405).send('Method Not Allowed');
+  }
+
+  const supabaseUrl = process.env.SUPABASE_URL;
+  const supabaseAnonKey = process.env.SUPABASE_ANON_KEY;
+
+  if (!supabaseUrl || !supabaseAnonKey) {
+    console.error('Missing Supabase environment variables for sitemap generation');
+    return res.status(500).send('Server configuration error');
+  }
+
+  const supabase = createClient(supabaseUrl, supabaseAnonKey);
+
+  const { data, error } = await supabase
+    .from('articles')
+    .select('id, updated_at, publish_at')
+    .eq('status', 'approved')
+    .order('updated_at', { ascending: false });
+
+  if (error) {
+    console.error('Failed to fetch sitemap entries:', error);
+    return res.status(500).send('Unable to generate sitemap');
+  }
+
+  const nowIso = new Date().toISOString();
+  const urls = (data ?? []).map((article) => {
+    const lastModified =
+      toIsoString(article.updated_at) ?? toIsoString(article.publish_at) ?? nowIso;
+
+    return `    <url>\n      <loc>${buildArticleUrl(article.id)}</loc>\n      <lastmod>${lastModified}</lastmod>\n    </url>`;
+  });
+
+  const sitemap = `<?xml version="1.0" encoding="UTF-8"?>\n` +
+    `<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n${urls.join('\n')}\n</urlset>`;
+
+  res.setHeader('Content-Type', 'application/xml');
+  res.setHeader('Cache-Control', 'public, s-maxage=3600, stale-while-revalidate=86400');
+
+  return res.status(200).send(sitemap);
+}

--- a/package.json
+++ b/package.json
@@ -10,6 +10,12 @@
     "lint": "eslint .",
     "preview": "vite preview"
   },
+  "reactSnap": {
+    "include": [
+      "/",
+      "/audit"
+    ]
+  },
   "dependencies": {
     "@hookform/resolvers": "^3.10.0",
     "@radix-ui/react-accordion": "^1.2.12",

--- a/robots.txt
+++ b/robots.txt
@@ -1,26 +1,5 @@
-# FlashAfrique - Robots.txt optimisé
+# FlashAfrique - Robots.txt
 User-agent: *
 Allow: /
 Disallow: /admin
-Disallow: /api/
-Disallow: /auth
-
-# Crawl delay pour éviter surcharge serveur
-Crawl-delay: 1
-
-# Sitemap (à générer dynamiquement)
 Sitemap: https://flashafrique.vercel.app/sitemap.xml
-
-# Agents spécifiques
-User-agent: Googlebot
-Allow: /
-Crawl-delay: 0
-
-User-agent: Bingbot
-Allow: /
-
-User-agent: Twitterbot
-Allow: /
-
-User-agent: facebookexternalhit
-Allow: /

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -62,6 +62,8 @@ const mapArticle = (article: Article): Article => ({
   publish_at: article.publish_at ?? '',
   country: article.country ?? '',
   source: article.source ?? '',
+  created_at: article.created_at ?? null,
+  updated_at: article.updated_at ?? article.publish_at ?? article.created_at ?? null,
 });
 
 export const fetchHomeArticles = async (signal?: AbortSignal): Promise<Article[]> => {

--- a/src/types/article.ts
+++ b/src/types/article.ts
@@ -11,6 +11,7 @@ export interface Article {
   country?: string | null;
   source?: string | null;
   created_at?: string | null;
+  updated_at?: string | null;
 }
 
 export interface CachedCategoryResponse {


### PR DESCRIPTION
## Summary
- add canonical, social meta tags, and NewsArticle JSON-LD to the article detail page for richer SEO metadata
- expose created/updated timestamps in article data and simplify robots directives for search engines
- serve a dynamic sitemap.xml endpoint and configure react-snap to pre-render the home and audit pages

## Testing
- pnpm run build

------
https://chatgpt.com/codex/tasks/task_e_68e189738d948322906bb4f9ad40a9a0