### PR TITLE
Add Lighthouse CI workflow

### DIFF
--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -1,0 +1,35 @@
+name: Lighthouse CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  lighthouse:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up PNPM
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build project
+        run: pnpm build
+
+      - name: Run Lighthouse CI
+        run: pnpm dlx @lhci/cli autorun --config=./lighthouserc.json

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # 🔍 Audit FlashAfrique - Rapport & Améliorations
 
+[![Lighthouse CI](https://github.com/flashafrique/flashafrique/actions/workflows/lighthouse.yml/badge.svg)](https://github.com/flashafrique/flashafrique/actions/workflows/lighthouse.yml)
+
 ## 📌 Vue d'ensemble
 
 Ce projet contient le **rapport d'audit complet** du site FlashAfrique ainsi que les **améliorations implémentées** suite à l'analyse technique.

--- a/lighthouserc.json
+++ b/lighthouserc.json
@@ -1,0 +1,19 @@
+{
+  "ci": {
+    "collect": {
+      "staticDistDir": "./dist",
+      "url": [
+        "/"
+      ]
+    },
+    "assert": {
+      "assertions": {
+        "categories:performance": ["error", { "minScore": 0.9 }],
+        "categories:seo": ["error", { "minScore": 0.9 }]
+      }
+    },
+    "upload": {
+      "target": "temporary-public-storage"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow that installs dependencies with pnpm, builds the app, and runs Lighthouse CI on push and pull requests to main
- configure Lighthouse CI to audit the built static site with performance and SEO thresholds set to 90
- add a README badge to highlight the Lighthouse CI workflow status

## Testing
- pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68e18ffb644c832292c657aa3865856e