### PR TITLE
chore(ci): fix Lighthouse CI to audit local dist

### DIFF
--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -1,0 +1,40 @@
+name: Lighthouse CI
+
+on:
+  pull_request:
+    branches: [ "main" ]
+  push:
+    branches: [ "main" ]
+
+jobs:
+  lighthouse:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup PNPM
+        uses: pnpm/action-setup@v4
+        with:
+          version: 8
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'pnpm'
+
+      - name: Install deps
+        run: pnpm install --frozen-lockfile=false
+
+      - name: Build site
+        run: pnpm build
+
+      - name: Run Lighthouse CI (static dist)
+        uses: treosh/lighthouse-ci-action@v11
+        with:
+          configPath: ./lighthouserc.json
+          temporaryPublicStorage: true
+          uploadArtifacts: true
+          runs: 1
+          # The action will auto-serve ./dist because staticDistDir is defined in lighthouserc.json

--- a/lighthouserc.json
+++ b/lighthouserc.json
@@ -1,0 +1,17 @@
+{
+  "ci": {
+    "collect": {
+      "staticDistDir": "./dist",
+      "numberOfRuns": 2,
+      "settings": {
+        "preset": "desktop"
+      }
+    },
+    "assert": {
+      "assertions": {
+        "categories:performance": ["warn", { "minScore": 0.90 }],
+        "categories:seo": ["warn", { "minScore": 0.90 }]
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- audit ./dist locally using treosh/lighthouse-ci-action with staticDistDir
- configure lighthouserc.json to run desktop preset and warn on scores under 90
- install/build in CI before running Lighthouse to ensure dist is available

## Testing
- pnpm install --frozen-lockfile=false
- pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68e195f88edc8322b47b23215a429b12