### PR TITLE
chore(ci): add LHCI urls for staticDistDir

### DIFF
--- a/lighthouserc.json
+++ b/lighthouserc.json
@@ -1,0 +1,31 @@
+{
+  "ci": {
+    "collect": {
+      "staticDistDir": "./dist",
+      "numberOfRuns": 2,
+      "settings": {
+        "preset": "desktop"
+      },
+      "url": [
+        "/",
+        "/audit"
+      ]
+    },
+    "assert": {
+      "assertions": {
+        "categories:performance": [
+          "warn",
+          {
+            "minScore": 0.9
+          }
+        ],
+        "categories:seo": [
+          "warn",
+          {
+            "minScore": 0.9
+          }
+        ]
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add '/' and '/audit' to the LHCI config so staticDistDir builds can be audited

## Testing
- pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68e19af9869c8322a692ed7074d0dc43